### PR TITLE
add case insensativity; 'url' -> 'html_url'

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -32,7 +32,7 @@ describe('index', () => {
         const temp = document.getElementById('issues-template').innerHTML
         expect(temp).toMatch(/{{#\s?each/)
         expect(temp).toMatch(/{{\/\s?each/)
-        expect(temp).toMatch(/{{\s?url\s?}}/)
+        expect(temp).toMatch(/{{\s?html_url\s?}}/)
         expect(temp).toMatch(/{{\s?body\s?}}/)
         expect(temp).toMatch(/{{\s?title\s?}}/)
       })
@@ -80,7 +80,7 @@ describe('index', () => {
       const url = fetchSpy.calls[0].arguments[0]
       expect(url).toMatch(/api.github.com\/repos\/learn-co-curriculum\/javascript-fetch-lab/)
       const opts = fetchSpy.calls[0].arguments[1]
-      expect(opts.method).toMatch(/post/)
+      expect(opts.method).toMatch(/post/i)
       expect(opts.headers).toMatch(/Authorization: token\s./)
     })
 
@@ -93,7 +93,7 @@ describe('index', () => {
       expect(url).toMatch(/javascript-fetch-lab\/issues/)
       expect(url).toNotMatch(/learn-co-curriculum/)
       const opts = fetchSpy.calls[0].arguments[1]
-      expect(opts.method).toMatch(/post/)
+      expect(opts.method).toMatch(/post/i)
       expect(opts.headers).toMatch(/Authorization: token\s./)
       expect(opts.body).toMatch(/test body/)
     })


### PR DESCRIPTION
Found a couple of small test cast improvements.  The RegEx for `/post/` didn't match when I had `POST` in the field.  Adding `i` makes it case insensitive.

One of the `{{ url }}`s in the solution links to the API url not the HTML url.
